### PR TITLE
Python 3 support

### DIFF
--- a/gnome-gocryptfs
+++ b/gnome-gocryptfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # =============================================================================
 #
@@ -326,7 +326,7 @@ def _is_mounted(mpoint):
 
     p = subprocess.Popen(["mount"], stdout=subprocess.PIPE)
     mount = p.communicate()[0]
-    lines = mount.strip('\n').split('\n')
+    lines = mount.decode().strip('\n').split('\n')
     points = map(lambda line: line.split()[2], lines)
     points = [os.path.abspath(p) for p in points]
     return os.path.abspath(mpoint) in points
@@ -573,7 +573,7 @@ def mount_items(path, autostart):
             command[1:1] = _config_commands(attributes["gocryptfs-config"])
 
             p = subprocess.Popen(command, stdin=subprocess.PIPE)
-            p.communicate(input="%s\n" % item.get_secret().get().decode())
+            p.communicate(input=b"%s\n" % item.get_secret().get())
             msg += p.returncode and "FAILED" or "OK"
             rc |= 0 if p.returncode == os.EX_OK else RC_MOUNT_FAILED
 

--- a/tests/test.exp
+++ b/tests/test.exp
@@ -181,15 +181,15 @@ autostart on
 # EXPECT: autostart on
 autostart on
 # EXPECT: autostart content
-[Desktop Entry]
-Comment=Mount gocryptfs folders configured in GNOME's keyring
-Name=Mount gocryptfs
-Exec=gnome-gocryptfs autostart
-Version=1.0
-Type=Application
-X-GNOME-Autostart-enabled=true
-Icon=folder
 
+Comment=Mount gocryptfs folders configured in GNOME's keyring
+[Desktop Entry]
+Exec=gnome-gocryptfs autostart
+Icon=folder
+Name=Mount gocryptfs
+Type=Application
+Version=1.0
+X-GNOME-Autostart-enabled=true
 # EXPECT: 1 succeeding edits
 # EXPECT: autostart off
 autostart off

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -127,7 +127,7 @@ $GGOCRYPTFS -e $TENV/m2 --econfig "-" --password p2 --epath $TENV/e2 --mpoint $T
 expect "autostart on"
 test -e autostart.desktop && echo "autostart on" ||  echo "autostart off"
 expect "autostart content"
-cat autostart.desktop
+cat autostart.desktop | sort # Ensure that the order does not matter
 expect "1 succeeding edits"
 $GGOCRYPTFS -e $TENV/m3b --econfig "-" --password p3 --epath $TENV/e3 --mpoint $TENV/m3b --proceed n --amount n
 expect "autostart off"


### PR DESCRIPTION
This PR introduces Python 3 support by handling the bytes/str cases. It also makes the test for the autostart file more robust by checking against the sorted content. Because the values are set from a dictionary, and this is likely also the case internally in `DestopEntry`, the order is not consistent.