### PR TITLE
List view and mounted flag

### DIFF
--- a/gnome-gocryptfs
+++ b/gnome-gocryptfs
@@ -491,7 +491,12 @@ def mount_items(args):
             ]
             command[1:1] = _config_commands(attributes["gocryptfs-config"])
 
-            p = subprocess.Popen(command, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             p.communicate(input=b"%s\n" % item.get_secret().get())
             msg += p.returncode and "FAILED" or "OK"
             rc |= 0 if p.returncode == os.EX_OK else RC_MOUNT_FAILED

--- a/gnome-gocryptfs
+++ b/gnome-gocryptfs
@@ -305,14 +305,20 @@ def list_items(args):
         print(MSG_NO_MATCH)
         return RC_UNKNOWN_ITEM
 
-    for item in items:
+    for i, item in enumerate(items):
+        if i > 0: print()
+
         attributes = item.get_attributes()
         attributes['auto-mount'] = 'yes' if attributes['auto-mount'] == 'y' else 'no'
+        if attributes['gocryptfs-config'] == '-':
+            attributes['gocryptfs-config'] = 'inline'
+        attributes['mounted'] = 'yes' if _is_mounted(attributes['mount-point']) else 'no'
 
-        message =  "* gocryptfs path   : {gocryptfs-path}\n"
-        message += "  mount point      : {mount-point}\n"
-        message += "  mount at login   : {auto-mount}\n"
-        message += "  gocryptfs config : {gocryptfs-config}"
+        message =  "STASH     : {gocryptfs-path}\n"
+        message += "MOUNT     : {mount-point}\n"
+        message += "CONFIG    : {gocryptfs-config}\n"
+        message += "AUTOMOUNT : {auto-mount}\n"
+        message += "MOUNTED   : {mounted}"
 
         print(message.format_map(attributes))
 

--- a/tests/test.exp
+++ b/tests/test.exp
@@ -1,59 +1,76 @@
 # EXPECT: no listed items
 # EXPECT: succeeding add (1)
 # EXPECT: 1 listed item (1)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: failing add - mount point in use
 Warning: mount point already in keyring
 # EXPECT: 1 listed item (1)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: succeeding add (2)
 # EXPECT: 2 listed items (1,2)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: succeeding add (3a)
 # EXPECT: 3 listed items (1,2,3a)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3a
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3a
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: succeeding add (3b)
 # EXPECT: 4 listed items (1,2,3a,3b)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3a
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3b
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3a
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3b
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: 2 succeeding mounts (3a,3b)
 Reading Password from stdin
 Decrypting master key
@@ -104,62 +121,82 @@ Unmounting ./tenv/m3a: OK
 Unmounting ./tenv/m3b: OK
 # EXPECT: no mounted paths - all unmounted
 # EXPECT: 3 items (1,2,3b)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3b
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3b
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: 3 items (1,2,3a)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3a
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3a
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: 3 items (1,2,3a)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3a
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3a
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: 1 failing mount (3a) - wrong password
 Reading Password from stdin
 Decrypting master key
 Mounting ./tenv/m3a: FAILED
 # EXPECT: no mounted paths
 # EXPECT: 3 items (1,2,3b)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3b
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3b
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: 1 succeeding mount (3b)
 Reading Password from stdin
 Decrypting master key
@@ -173,18 +210,23 @@ Unmounting ./tenv/m3b: OK
 # EXPECT: failing edit (3b->2) - mount point in use
 Warning: mount point already in use
 # EXPECT: 3 items (1,2,3b)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e2
-  mount point      : ./tenv/m2
-  mount at login   : yes
-  gocryptfs config : -
-* gocryptfs path   : ./tenv/e3
-  mount point      : ./tenv/m3b
-  mount at login   : yes
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e2
+MOUNT     : ./tenv/m2
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
+
+STASH     : ./tenv/e3
+MOUNT     : ./tenv/m3b
+CONFIG    : inline
+AUTOMOUNT : yes
+MOUNTED   : no
 # EXPECT: autostart on
 autostart on
 # EXPECT: 2 succeeding edits
@@ -205,10 +247,11 @@ X-GNOME-Autostart-enabled=true
 autostart off
 # EXPECT: succeeding add (1) with custom config file location
 # EXPECT: 1 listed item (1)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : no
-  gocryptfs config : ./tenv/e1_gocryptfs.conf
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : ./tenv/e1_gocryptfs.conf
+AUTOMOUNT : no
+MOUNTED   : no
 # EXPECT: 1 succeeding mounts (1)
 Using config file at custom location ./tenv/e1_gocryptfs.conf
 Reading Password from stdin
@@ -222,16 +265,18 @@ Unmounting ./tenv/m1: OK
 # EXPECT: no mounted paths - all unmounted
 # EXPECT: succeeding edit (1) reset config file location
 # EXPECT: 1 listed item (1)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : no
-  gocryptfs config : -
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : inline
+AUTOMOUNT : no
+MOUNTED   : no
 # EXPECT: succeeding edit (1) with custom config file location
 # EXPECT: 1 listed item (1)
-* gocryptfs path   : ./tenv/e1
-  mount point      : ./tenv/m1
-  mount at login   : no
-  gocryptfs config : ./tenv/e1_gocryptfs.conf
+STASH     : ./tenv/e1
+MOUNT     : ./tenv/m1
+CONFIG    : ./tenv/e1_gocryptfs.conf
+AUTOMOUNT : no
+MOUNTED   : no
 # EXPECT: succeeding remove (1)
 # EXPECT: 0 items
 # EXPECT: no listed items

--- a/tests/test.exp
+++ b/tests/test.exp
@@ -72,12 +72,6 @@ CONFIG    : inline
 AUTOMOUNT : yes
 MOUNTED   : no
 # EXPECT: 2 succeeding mounts (3a,3b)
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
 Mounting ./tenv/m3a: OK
 Mounting ./tenv/m3b: OK
 # EXPECT: 2 mounted paths (3a,3b)
@@ -88,18 +82,6 @@ Unmounting ./tenv/m3a: OK
 Unmounting ./tenv/m3b: OK
 # EXPECT: no mounted paths - all unmounted
 # EXPECT: 4 succeeding mounts (1,2,3a,3b)
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
 Mounting ./tenv/m1: OK
 Mounting ./tenv/m2: OK
 Mounting ./tenv/m3a: OK
@@ -175,8 +157,6 @@ CONFIG    : inline
 AUTOMOUNT : yes
 MOUNTED   : no
 # EXPECT: 1 failing mount (3a) - wrong password
-Reading Password from stdin
-Decrypting master key
 Mounting ./tenv/m3a: FAILED
 # EXPECT: no mounted paths
 # EXPECT: 3 items (1,2,3b)
@@ -198,9 +178,6 @@ CONFIG    : inline
 AUTOMOUNT : yes
 MOUNTED   : no
 # EXPECT: 1 succeeding mount (3b)
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
 Mounting ./tenv/m3b: OK
 # EXPECT: 1 mounted path (3b)
 ./tenv/m3b type fuse.gocryptfs
@@ -253,10 +230,6 @@ CONFIG    : ./tenv/e1_gocryptfs.conf
 AUTOMOUNT : no
 MOUNTED   : no
 # EXPECT: 1 succeeding mounts (1)
-Using config file at custom location ./tenv/e1_gocryptfs.conf
-Reading Password from stdin
-Decrypting master key
-Filesystem mounted and ready.
 Mounting ./tenv/m1: OK
 # EXPECT: 1 mounted paths (1)
 ./tenv/m1 type fuse.gocryptfs

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -26,7 +26,7 @@ rm -rf $TENV
 tar xf tenv.tar
 
 # clean up keyring
-$GGOCRYPTFS list | grep "mount point" | grep "/tenv/m[0-9]" | awk {'print $4'} | \
+$GGOCRYPTFS list | grep "^MOUNT " | grep "/tenv/m[0-9]" | awk {'print $3'} | \
     while read MP ; do $GGOCRYPTFS remove $MP ; done
 
 # start tests
@@ -134,7 +134,7 @@ test -e autostart.desktop && echo "autostart on" ||  echo "autostart off"
 
 # clean up keyring
 
-$GGOCRYPTFS list | grep "mount point" | grep "/tenv/m[0-9]" | awk {'print $4'} | \
+$GGOCRYPTFS list | grep "^MOUNT " | grep "/tenv/m[0-9]" | awk {'print $3'} | \
     while read MP ; do $GGOCRYPTFS remove $MP ; done
 
 # test custom gocryptfs config file location
@@ -174,7 +174,7 @@ expect "0 items"
 $GGOCRYPTFS list
 
 # clean up keyring
-$GGOCRYPTFS list | grep "mount point" | grep "/tenv/m[0-9]" | awk {'print $4'} | \
+$GGOCRYPTFS list | grep "^MOUNT " | grep "/tenv/m[0-9]" | awk {'print $3'} | \
     while read MP ; do $GGOCRYPTFS remove $MP ; done
 
 expect "no listed items"


### PR DESCRIPTION
This PR simplifies the list view and adds an additional field to show if the stash is mounted. It also silences the stdout messages from `gocryptfs` during mounting.
```
$ gnome-gocryptfs list
STASH     : /home/user/e1
MOUNT     : /home/user/m1
CONFIG    : inline
AUTOMOUNT : no
MOUNTED   : no
$ gnome-gocryptfs mount ~/m1
Mounting /home/user/e1 at /home/user/m1: OK
$ gnome-gocryptfs list
STASH     : /home/user/e1
MOUNT     : /home/user/m1
CONFIG    : inline
AUTOMOUNT : no
MOUNTED   : yes
$ gnome-gocryptfs unmount ~/m1
Unmounting /home/user/e1 at /home/user/m1: OK
$ gnome-gocryptfs list
STASH     : /home/user/e1
MOUNT     : /home/user/m1
CONFIG    : inline
AUTOMOUNT : no
MOUNTED   : no
```