### PR TITLE
Fix "Mount at login" input prompt when auto-mount attributes is false.

### DIFF
--- a/gnome-gocryptfs
+++ b/gnome-gocryptfs
@@ -405,7 +405,7 @@ def edit_item(args):
         )
         attributes["auto-mount"] = (
             args.auto_mount or
-            input("Mount at login [%s]: " % "Y/n" if attributes["auto-mount"] == "y" else "y/N") or
+            input("Mount at login [%s]: " % ("Y/n" if attributes["auto-mount"] == "y" else "y/N")) or
             attributes["auto-mount"]
         )
         attributes["auto-mount"] = (


### PR DESCRIPTION
When you edit an existing entry for which the `auto-mount` attributes is false, the prompt is:
`y/N`
instead of:
`Mount at login [Y/n]`
