### PR TITLE
Use systemd to unmount gocryptfs folders on logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ gnome-gocryptfs
 ![](https://github.com/cjermain/gnome-gocryptfs/workflows/Run%20Tests/badge.svg)
 
 *gnome-gocryptfs* integrates [gocryptfs][cfs] folders into the GNOME desktop by storing
-their passwords in the [keyring][gkr] and optionally mounting them at login
-using GNOME's autostart mechanism. This package is a fork of the [gnome-encfs][gef]
-project.
+their passwords in the [keyring][gkr] and optionally mounting them at login (and
+unmouting them at logout
+[on most distribution](#automatically-unmount-gocryptfs-folders-on-logout)). This package
+is a fork of the [gnome-encfs][gef] project.
 
 *gnome-gocryptfs* allows you to use strong passwords for gocryptfs folders while still
 mounting them painlessly (i.e. no password prompt).  This is an advantage over
@@ -97,9 +98,15 @@ Usage should be straight forward - otherwise [submit an issue][itr].
 
 ### Automatically unmount gocryptfs folders on logout
 
-Unfortunately there's no equivalent to GNOME's autostart scripts which could be
-used to automatically unmount your gocryptfs folders on logout (without shutting
-down). However, there's a manual solution using a [GDM hook script][gdm]:
+If your distribution uses systemd to handle user sessions, your gocryptfs folders
+will be automatically mounted/unmounted at login/logout.
+
+Otherwise, gocryptfs folders can still be automatically mount at login using GNOME's
+autostart mechanism. Unfortunately there's no equivalent to GNOME's autostart scripts
+which could be used to automatically unmount your gocryptfs folders on logout
+(without shutting down).
+
+However, there's a manual solution using a [GDM hook script][gdm]:
 `/etc/gdm/PostSession/Default`. Open this file in an editor (requires *root*
 privileges) and add these lines:
 
@@ -128,4 +135,3 @@ License
 [gkr]: http://live.gnome.org/GnomeKeyring
 [gpl]: http://www.gnu.org/licenses/gpl.html
 [itr]: https://github.com/cjermain/gnome-gocryptfs/issues
-

--- a/gnome-gocryptfs
+++ b/gnome-gocryptfs
@@ -38,8 +38,10 @@ from gi.repository import Secret
 
 __version__ = "0.3"
 
-TEST = "GNOME_GOCRYPTFS_TEST" in os.environ
-
+TEST_ENV_VARNAME = "GNOME_GOCRYPTFS_TEST"
+TEST_SYSTEMD_TOKEN = "SYSTEMD"
+TEST = TEST_ENV_VARNAME in os.environ
+TEST_TYPE = os.environ[TEST_ENV_VARNAME] if TEST else ""
 
 class LockedKeyring(Exception):
     pass
@@ -181,6 +183,13 @@ MSG_NO_MATCH = ("No matching gocryptfs items in keyring.\n"
 MSG_NO_GOCRYPTFS_PATH = ("No gocryptfs at given path (or the gocryptfs config file "
                      "location is invalid)")
 
+MSG_NO_SYSTEMD_SESSION = (
+    "*WARNING* Systemd doesn't handle user sessions. Fallback to "
+    "GNOME's autostart mechanism.\n"
+    "Your gocryptfs folders will not be unmounted on logout. See gnome-gocryptfs "
+    "README for a workaround."
+)
+
 DESCRIPTION = """Painlessly mount and manage gocryptfs folders using GNOME's
 keyring."""
 
@@ -258,7 +267,62 @@ def _is_gocryptfs(path, config):
     p.communicate()
     return p.returncode == 0
 
-def _autostart(enable):
+def _enable_systemd_unit(enable):
+    command = [
+        "systemctl",
+        "--user",
+        "enable" if enable else "disable",
+        "gnome-gocryptfs.service",
+    ]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p.communicate()
+    if p.returncode != 0:
+        print(
+            f"Failed to {'enable' if enable else 'disable'} gnome-gocryptfs service in systemd"
+        )
+
+def _create_systemd_unit(enable):
+    """Set up a systemd user unit to automount folders when user logins"""
+
+    if TEST:
+        fname = os.path.join(os.path.curdir, "autostart.service")
+    else:
+        fname = os.path.join(xdg_config_home, "systemd/user", "gnome-gocryptfs.service")
+
+    if not enable:
+        _enable_systemd_unit(enable)
+        if os.path.exists(fname):
+            os.remove(fname)
+        return
+
+    # Systemd user config directory may not exist...
+    os.makedirs(os.path.dirname(fname), exist_ok=True)
+
+    # '~/.local/bin' is not in the default PATH (in systemd user unit)
+    # So use the absolute path to this script.
+    # TODO: Remove this test patch
+    our_path = os.path.realpath(__file__) if not TEST else "gnome-gocryptfs"
+    content = (
+        "[Unit]\n"
+        "Description=Gnome gocryptfs automounter service\n"
+        "PartOf=graphical-session.target\n"
+        "\n"
+        "[Service]\n"
+        "Type=oneshot\n"
+        "RemainAfterExit=yes\n"
+        f"ExecStart={our_path} mount --auto\n"
+        f"ExecStop={our_path} unmount\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=graphical-session.target\n"
+    )
+
+    with open(fname, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    _enable_systemd_unit(enable)
+
+def _create_desktop_file(enable):
     """Set up XDG autostart file."""
 
     if TEST:
@@ -285,6 +349,32 @@ def _autostart(enable):
         entry.set(key, value)
     entry.validate()
     entry.write()
+
+def _autostart(enable):
+    """Ensure folders are automatically mount and properly unmounted."""
+
+    # Test if user sessions are handled by systemd
+    command = [
+        "systemctl",
+        "--user",
+        "is-enabled",
+        "--quiet",
+        "graphical-session.target",
+    ]
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p.communicate()
+
+    # TODO: Remove this test patch
+    is_systemd_available = (p.returncode == 0) if not TEST else (TEST_TYPE == TEST_SYSTEMD_TOKEN)
+
+    if is_systemd_available:
+        _create_desktop_file(False)
+        _create_systemd_unit(enable)
+    else:  # Fallback to GNOME's autostart mechanism
+        print(MSG_NO_SYSTEMD_SESSION)
+        _create_systemd_unit(False)
+        _create_desktop_file(enable)
+
 
 # =============================================================================
 # actions

--- a/tests/test.exp
+++ b/tests/test.exp
@@ -210,6 +210,29 @@ autostart on
 # EXPECT: autostart on
 autostart on
 # EXPECT: autostart content
+[Unit]
+Description=Gnome gocryptfs automounter service
+PartOf=graphical-session.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=gnome-gocryptfs mount --auto
+ExecStop=gnome-gocryptfs unmount
+
+[Install]
+WantedBy=graphical-session.target
+# EXPECT: 1 succeeding edits
+# EXPECT: autostart off
+autostart off
+# EXPECT: autostart using desktop method
+*WARNING* Systemd doesn't handle user sessions. Fallback to GNOME's autostart mechanism.
+Your gocryptfs folders will not be unmounted on logout. See gnome-gocryptfs README for a workaround.
+# EXPECT: autostart systemd off
+autostart systemd off
+# EXPECT: autostart desktop on
+autostart desktop on
+# EXPECT: autostart desktop content
 
 Comment=Mount gocryptfs folders configured in GNOME's keyring
 [Desktop Entry]
@@ -219,9 +242,11 @@ Name=Mount gocryptfs
 Type=Application
 Version=1.0
 X-GNOME-Autostart-enabled=true
-# EXPECT: 1 succeeding edits
-# EXPECT: autostart off
-autostart off
+# EXPECT: autostart using systemd method
+# EXPECT: autostart systemd on
+autostart systemd on
+# EXPECT: autostart desktop off
+autostart desktop off
 # EXPECT: succeeding add (1) with custom config file location
 # EXPECT: 1 listed item (1)
 STASH     : ./tenv/e1


### PR DESCRIPTION
When user sessions are handled by `systemd`, we use it to unmount gocryptfs folders at logout (and avoid adding manually a GDM hook).

If `systemd` handles user sessions, a systemd user service will be created to mount gocryptfs folders when you start the service and unmount them when you stop the service.

Then through systemd dependencies to `graphical-session.target`, we start this service on login and stop it on logout in order to mount/unmount gocryptfs folders automatically.

If `systemd` doesn't handle user session, the old mechanism (GNOME's autostart) is used.